### PR TITLE
Feature/oc 451/programatically select radio

### DIFF
--- a/pwa/src/templates/templateParts/filters/verticalFilters/VerticalFiltersTemplate.tsx
+++ b/pwa/src/templates/templateParts/filters/verticalFilters/VerticalFiltersTemplate.tsx
@@ -251,17 +251,6 @@ export const VerticalFiltersTemplate: React.FC<VerticalFiltersTemplateProps> = (
     });
   }, [filters["maintenance.type"]]);
 
-  React.useEffect(() => {
-    const unsetSoftwareTypeFilter = softwareTypes.filter((softwareType) => filters.softwareType !== softwareType.value);
-
-    unsetSoftwareTypeFilter.map((SoftwareType: any) => {
-      var checkBox = document.getElementById(`checkbox${SoftwareType.label}`) as HTMLInputElement | null;
-      if (checkBox && checkBox.checked == true) {
-        checkBox.checked = false;
-      }
-    });
-  }, [filters.softwareType]);
-
   return (
     <div className={clsx(styles.container, layoutClassName && layoutClassName)}>
       <Collapsible
@@ -537,11 +526,11 @@ export const VerticalFiltersTemplate: React.FC<VerticalFiltersTemplateProps> = (
                     key={softwareType.value}
                   >
                     <input
-                      id={`checkbox${softwareType.label}`}
                       type="radio"
                       value={softwareType.value}
-                      name="softwareTypes"
-                    />{" "}
+                      {...register("softwareTypes")}
+                      checked={filters.softwareType === softwareType.value}
+                    />
                     {softwareType.label}
                   </div>
                 ))}

--- a/pwa/src/templates/templateParts/filters/verticalFilters/VerticalFiltersTemplate.tsx
+++ b/pwa/src/templates/templateParts/filters/verticalFilters/VerticalFiltersTemplate.tsx
@@ -227,19 +227,6 @@ export const VerticalFiltersTemplate: React.FC<VerticalFiltersTemplateProps> = (
     });
   }, [filters.platforms]);
 
-  React.useEffect(() => {
-    const unsetMaintenenceTypeFilter = maintenanceTypes.filter(
-      (maintenenceType) => filters["maintenance.type"] !== maintenenceType.value,
-    );
-
-    unsetMaintenenceTypeFilter.map((MaintenenceType: any) => {
-      var checkBox = document.getElementById(`checkbox${MaintenenceType.label}`) as HTMLInputElement | null;
-      if (checkBox && checkBox.checked == true) {
-        checkBox.checked = false;
-      }
-    });
-  }, [filters["maintenance.type"]]);
-
   return (
     <div className={clsx(styles.container, layoutClassName && layoutClassName)}>
       <Collapsible
@@ -452,10 +439,10 @@ export const VerticalFiltersTemplate: React.FC<VerticalFiltersTemplateProps> = (
                     key={maintenanceType.value}
                   >
                     <input
-                      id={`checkbox${maintenanceType.label}`}
                       type="radio"
                       value={maintenanceType.value}
-                      name="maintenanceType"
+                      {...register("maintenanceType")}
+                      checked={filters["maintenance.type"] === maintenanceType.value}
                     />
                     {maintenanceType.label}
                   </div>

--- a/pwa/src/templates/templateParts/filters/verticalFilters/VerticalFiltersTemplate.tsx
+++ b/pwa/src/templates/templateParts/filters/verticalFilters/VerticalFiltersTemplate.tsx
@@ -228,17 +228,6 @@ export const VerticalFiltersTemplate: React.FC<VerticalFiltersTemplateProps> = (
   }, [filters.platforms]);
 
   React.useEffect(() => {
-    const unsetStatusFilter = statuses.filter((status) => filters.developmentStatus !== status.value);
-
-    unsetStatusFilter.map((status: any) => {
-      var checkBox = document.getElementById(`checkbox${status.label}`) as HTMLInputElement | null;
-      if (checkBox && checkBox.checked == true) {
-        checkBox.checked = false;
-      }
-    });
-  }, [filters.developmentStatus]);
-
-  React.useEffect(() => {
     const unsetMaintenenceTypeFilter = maintenanceTypes.filter(
       (maintenenceType) => filters["maintenance.type"] !== maintenenceType.value,
     );
@@ -420,7 +409,12 @@ export const VerticalFiltersTemplate: React.FC<VerticalFiltersTemplateProps> = (
                     onChange={() => setStatusRadioFilter(status.value)}
                     key={status.value}
                   >
-                    <input id={`checkbox${status.label}`} type="radio" value={status.value} name="status" />{" "}
+                    <input
+                      type="radio"
+                      value={status.value}
+                      {...register("status")}
+                      checked={filters.developmentStatus === status.value}
+                    />
                     {status.label}
                   </div>
                 ))}


### PR DESCRIPTION
Rewrites logic of radio buttons in the filters. Was necessary due to radio buttons never being pre-selected when the filters were updated programatically. 

With this refactor, we use the power of react-hook-form more and decrease the need for custom code and logic.

(Note: we had a couple of `document.getElementById` queries in this logic, which is not really the _"React way"_ of doing things).